### PR TITLE
Mark repo as archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # verify-slack-java-cli
+
+> **Verify has Closed**
+>
+>This repository is out of date and has been archived
+
 Simple cli tool to interact with Slack from within a Concourse pipeline (or anywhere else really).
 
 ## Suggested usage instructions


### PR DESCRIPTION
As agreed in [verify-architecture ADR 0039](https://github.com/alphagov/verify-architecture/blob/master/adr/0039-use-prs-before-archiving-repos.md), a PR must be approved by all engineers on the team before being archived.

Approving this PR indicates approval for this repo to be archived.